### PR TITLE
feat(options): Add skipLocales option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Options:
   --skip-content-model            Skips content types and locales. Copies only entries and assets
                                   [boolean]
 
+  --skip-locales                  Skips locales. Must be used with --content-model-only.
+                                  Copies only content types.
+                                  [boolean]
+
   --force-overwrite               Forces overwrite of content on the destination
                                   space with the same ID. BEFORE USING THIS
                                   option see the section "Overwriting Content"

--- a/lib/run-space-sync.js
+++ b/lib/run-space-sync.js
@@ -48,9 +48,15 @@ export default function runSpaceSync (usageParams) {
       responses.source.deletedContentTypes = filter(responses.destination.contentTypes, (contentType) => {
         return !find(responses.source.contentTypes, {original: {sys: {id: contentType.sys.id}}})
       })
-      responses.source.deletedLocales = filter(responses.destination.locales, (locale) => {
-        return !find(responses.source.locales, {original: {code: locale.code}})
-      })
+
+      if (opts.skipLocales) {
+        responses.source.locales = []
+      } else {
+        responses.source.deletedLocales = filter(responses.destination.locales, (locale) => {
+          return !find(responses.source.locales, {original: {code: locale.code}})
+        })
+      }
+
       return responses
     })
 

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -53,6 +53,10 @@ var opts = yargs
     describe: 'Skips content types and locales. Copies only entries and assets',
     type: 'boolean'
   })
+  .option('skip-locales', {
+    describe: 'Skips locales. Must be used with content-model-only. Copies only content-types',
+    type: 'boolean'
+  })
   .option('force-overwrite', {
     describe: 'Forces overwrite of content on the destination space with the same ID. BEFORE USING THIS option see the section "Overwriting Content" on the README for more details.',
     type: 'boolean'
@@ -88,6 +92,13 @@ var opts = yargs
   .check(function (argv) {
     if (argv.skipContentModel && argv.contentModelOnly) {
       log.error('--skipContentModel and --contentModelOnly cannot be used together')
+      process.exit(1)
+    }
+    return true
+  })
+  .check(function (argv) {
+    if (argv.skipLocales && !argv.contentModelOnly) {
+      log.error('--skipLocales can only be used with --contentModelOnly')
       process.exit(1)
     }
     return true


### PR DESCRIPTION
This adds the ```--skipLocales``` option, if you want to synchronise your content-types but not the locales.

I am not sure about your commit messages convention. Let me know if I need to update anything.