### PR TITLE
fix(opts): move validation of the opts to later stage

### DIFF
--- a/lib/run-space-sync.js
+++ b/lib/run-space-sync.js
@@ -13,12 +13,12 @@ import dumpErrorBuffer from './dump-error-buffer'
 import getTransformedDestinationResponse from './get-transformed-destination-response'
 
 export default function runSpaceSync (usageParams) {
-  const {opts} = usageParams
+  let {opts, errorLogFile, syncTokenFile} = usageParams
   opts.sourceManagementToken = opts.sourceManagementToken || opts.managementToken
   opts.destinationManagementToken = opts.destinationManagementToken || opts.managementToken
   const tokenDir = opts.syncTokenDir || process.cwd()
-  opts.errorLogFile = tokenDir + '/contentful-space-sync-' + Date.now() + '.log'
-  opts.syncTokenFile = tokenDir + '/contentful-space-sync-token-' + opts.sourceSpace + '-to-' + opts.destinationSpace
+  errorLogFile = errorLogFile || tokenDir + '/contentful-space-sync-' + Date.now() + '.log'
+  syncTokenFile = syncTokenFile || tokenDir + '/contentful-space-sync-token-' + opts.sourceSpace + '-to-' + opts.destinationSpace
 
   if (opts.proxyHost && opts.proxyPort) {
     opts.proxy = {host: opts.proxyHost, port: opts.proxyPort}
@@ -28,7 +28,7 @@ export default function runSpaceSync (usageParams) {
     deliveryClient: clients.source.delivery,
     managementClient: clients.source.management,
     sourceSpaceId: clients.source.spaceId,
-    nextSyncTokenFile: opts.syncTokenFile
+    nextSyncTokenFile: syncTokenFile
   })
 
     // Prepare object with both source and destination existing content
@@ -77,11 +77,7 @@ export default function runSpaceSync (usageParams) {
         .then(() => {
           const nextSyncToken = responses.source.nextSyncToken
           if (!opts.contentModelOnly && nextSyncToken) {
-            try {
-              fs.writeFileSync(opts.syncTokenFile, nextSyncToken)
-            } catch (e) {
-              log.info('Cannot write synckToen to fileSystem, ', e)
-            }
+            fs.writeFileSync(syncTokenFile, nextSyncToken)
             log.info('Successfully sychronized the content and saved the sync token to:\n ', opts.syncTokenFile)
           } else {
             log.info('Successfully sychronized the content model')
@@ -89,7 +85,7 @@ export default function runSpaceSync (usageParams) {
           dumpErrorBuffer({
             destinationSpace: opts.destinationSpace,
             sourceSpace: opts.sourceSpace,
-            errorLogFile: opts.errorLogFile
+            errorLogFile: errorLogFile
           }, 'However, additional errors were found')
 
           return {

--- a/lib/run-space-sync.js
+++ b/lib/run-space-sync.js
@@ -14,6 +14,9 @@ import getTransformedDestinationResponse from './get-transformed-destination-res
 
 export default function runSpaceSync (usageParams) {
   const {opts, syncTokenFile, errorLogFile} = usageParams
+  opts.sourceManagementToken = opts.sourceManagementToken || opts.managementToken
+  opts.destinationManagementToken = opts.destinationManagementToken || opts.managementToken
+
   if (opts.proxyHost && opts.proxyPort) {
     opts.proxy = {host: opts.proxyHost, port: opts.proxyPort}
   }

--- a/lib/run-space-sync.js
+++ b/lib/run-space-sync.js
@@ -16,7 +16,8 @@ export default function runSpaceSync (usageParams) {
   const {opts, syncTokenFile, errorLogFile} = usageParams
   opts.sourceManagementToken = opts.sourceManagementToken || opts.managementToken
   opts.destinationManagementToken = opts.destinationManagementToken || opts.managementToken
-
+  opts.syncTokenDir = opts.syncTokenDir || process.cwd()
+  
   if (opts.proxyHost && opts.proxyPort) {
     opts.proxy = {host: opts.proxyHost, port: opts.proxyPort}
   }
@@ -74,7 +75,11 @@ export default function runSpaceSync (usageParams) {
         .then(() => {
           const nextSyncToken = responses.source.nextSyncToken
           if (!opts.contentModelOnly && nextSyncToken) {
-            fs.writeFileSync(syncTokenFile, nextSyncToken)
+            try {
+              fs.writeFileSync(syncTokenFile, nextSyncToken)
+            } catch(e) {
+              log.info('Cannot write synckToen to fileSystem, ', e)
+            }
             log.info('Successfully sychronized the content and saved the sync token to:\n ', syncTokenFile)
           } else {
             log.info('Successfully sychronized the content model')

--- a/lib/run-space-sync.js
+++ b/lib/run-space-sync.js
@@ -13,7 +13,7 @@ import dumpErrorBuffer from './dump-error-buffer'
 import getTransformedDestinationResponse from './get-transformed-destination-response'
 
 export default function runSpaceSync (usageParams) {
-  const {optst} , errorLogFile} = usageParams
+  const {opts} = usageParams
   opts.sourceManagementToken = opts.sourceManagementToken || opts.managementToken
   opts.destinationManagementToken = opts.destinationManagementToken || opts.managementToken
   const tokenDir = opts.syncTokenDir || process.cwd()

--- a/lib/run-space-sync.js
+++ b/lib/run-space-sync.js
@@ -13,10 +13,10 @@ import dumpErrorBuffer from './dump-error-buffer'
 import getTransformedDestinationResponse from './get-transformed-destination-response'
 
 export default function runSpaceSync (usageParams) {
-  const {opts, syncTokenFile, errorLogFile} = usageParams
+  const {optst} , errorLogFile} = usageParams
   opts.sourceManagementToken = opts.sourceManagementToken || opts.managementToken
   opts.destinationManagementToken = opts.destinationManagementToken || opts.managementToken
-  const tokenDir = opts.syncTokenDir || __dirname
+  const tokenDir = opts.syncTokenDir || process.cwd()
   opts.errorLogFile = tokenDir + '/contentful-space-sync-' + Date.now() + '.log'
   opts.syncTokenFile = tokenDir + '/contentful-space-sync-token-' + opts.sourceSpace + '-to-' + opts.destinationSpace
 
@@ -28,7 +28,7 @@ export default function runSpaceSync (usageParams) {
     deliveryClient: clients.source.delivery,
     managementClient: clients.source.management,
     sourceSpaceId: clients.source.spaceId,
-    nextSyncTokenFile: syncTokenFile
+    nextSyncTokenFile: opts.syncTokenFile
   })
 
     // Prepare object with both source and destination existing content
@@ -78,18 +78,18 @@ export default function runSpaceSync (usageParams) {
           const nextSyncToken = responses.source.nextSyncToken
           if (!opts.contentModelOnly && nextSyncToken) {
             try {
-              fs.writeFileSync(syncTokenFile, nextSyncToken)
+              fs.writeFileSync(opts.syncTokenFile, nextSyncToken)
             } catch (e) {
               log.info('Cannot write synckToen to fileSystem, ', e)
             }
-            log.info('Successfully sychronized the content and saved the sync token to:\n ', syncTokenFile)
+            log.info('Successfully sychronized the content and saved the sync token to:\n ', opts.syncTokenFile)
           } else {
             log.info('Successfully sychronized the content model')
           }
           dumpErrorBuffer({
             destinationSpace: opts.destinationSpace,
             sourceSpace: opts.sourceSpace,
-            errorLogFile: errorLogFile
+            errorLogFile: opts.errorLogFile
           }, 'However, additional errors were found')
 
           return {

--- a/lib/run-space-sync.js
+++ b/lib/run-space-sync.js
@@ -16,8 +16,10 @@ export default function runSpaceSync (usageParams) {
   const {opts, syncTokenFile, errorLogFile} = usageParams
   opts.sourceManagementToken = opts.sourceManagementToken || opts.managementToken
   opts.destinationManagementToken = opts.destinationManagementToken || opts.managementToken
-  opts.syncTokenDir = opts.syncTokenDir || process.cwd()
-  
+  const tokenDir = opts.syncTokenDir || process.cwd()
+  opts.errorLogFile = tokenDir + '/contentful-space-sync-' + Date.now() + '.log'
+  opts.syncTokenFile = tokenDir + '/contentful-space-sync-token-' + opts.sourceSpace + '-to-' + opts.destinationSpace
+
   if (opts.proxyHost && opts.proxyPort) {
     opts.proxy = {host: opts.proxyHost, port: opts.proxyPort}
   }
@@ -77,7 +79,7 @@ export default function runSpaceSync (usageParams) {
           if (!opts.contentModelOnly && nextSyncToken) {
             try {
               fs.writeFileSync(syncTokenFile, nextSyncToken)
-            } catch(e) {
+            } catch (e) {
               log.info('Cannot write synckToen to fileSystem, ', e)
             }
             log.info('Successfully sychronized the content and saved the sync token to:\n ', syncTokenFile)

--- a/lib/run-space-sync.js
+++ b/lib/run-space-sync.js
@@ -16,7 +16,7 @@ export default function runSpaceSync (usageParams) {
   const {opts, syncTokenFile, errorLogFile} = usageParams
   opts.sourceManagementToken = opts.sourceManagementToken || opts.managementToken
   opts.destinationManagementToken = opts.destinationManagementToken || opts.managementToken
-  const tokenDir = opts.syncTokenDir || process.cwd()
+  const tokenDir = opts.syncTokenDir || __dirname
   opts.errorLogFile = tokenDir + '/contentful-space-sync-' + Date.now() + '.log'
   opts.syncTokenFile = tokenDir + '/contentful-space-sync-token-' + opts.sourceSpace + '-to-' + opts.destinationSpace
 

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -149,8 +149,6 @@ var opts = yargs
   })
   .argv
 
-var tokenDir = opts.syncTokenDir || process.cwd()
-
 module.exports = {
   opts: opts,
   errorLogFile: tokenDir + '/contentful-space-sync-' + Date.now() + '.log',

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -150,7 +150,5 @@ var opts = yargs
   .argv
 
 module.exports = {
-  opts: opts,
-  errorLogFile: tokenDir + '/contentful-space-sync-' + Date.now() + '.log',
-  syncTokenFile: tokenDir + '/contentful-space-sync-token-' + opts.sourceSpace + '-to-' + opts.destinationSpace
+  opts: opts
 }

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -149,9 +149,6 @@ var opts = yargs
   })
   .argv
 
-opts.sourceManagementToken = opts.sourceManagementToken || opts.managementToken
-opts.destinationManagementToken = opts.destinationManagementToken || opts.managementToken
-
 var tokenDir = opts.syncTokenDir || process.cwd()
 
 module.exports = {


### PR DESCRIPTION
Fixing https://github.com/contentful/contentful-space-sync/issues/102 and https://github.com/contentful/contentful-space-sync/issues/103 when the library tool is used as a library.

TODO : 
- [x] Fix managementToken validation
- [x] Set syncTokenFile to pwd if not defined, when the tool is used as a library

